### PR TITLE
Added key schema calculation for Ecto.Query

### DIFF
--- a/README.md
+++ b/README.md
@@ -20,16 +20,16 @@ end
 Suppose you have an Ecto repo:
 
 ```elixir
-defmodule MyApp.Cache do
-  use Nebulex.Cache, otp_app: :my_app
+defmodule MyApp.Repo do
+  use Ecto.Repo, otp_app: :my_app
 end
 ```
 
 And a Nebulex cache:
 
 ```elixir
-defmodule MyApp.Repo do
-  use Ecto.Repo, otp_app: :my_app
+defmodule MyApp.Cache do
+  use Nebulex.Cache, otp_app: :my_app
 end
 ```
 

--- a/lib/nebulex_ecto/repo.ex
+++ b/lib/nebulex_ecto/repo.ex
@@ -179,6 +179,8 @@ defmodule Nebulex.Ecto.Repo do
       defp cache_evict(:replace, key, value),
         do: @cache.set(key, value)
 
+      defp key!(%Ecto.Query{from: {_tablename, schema}}, key),
+        do: {schema, key}
       defp key!(%{__struct__: struct}, key),
         do: {struct, key}
       defp key!(struct, key) when is_atom(struct),

--- a/test/nebulex_ecto/repo_test.exs
+++ b/test/nebulex_ecto/repo_test.exs
@@ -1,6 +1,7 @@
 defmodule Nebulex.Ecto.RepoTest do
   use ExUnit.Case, async: true
 
+  import Ecto.Query
   alias Nebulex.Ecto.TestRepo, as: Repo
   alias Nebulex.Ecto.TestCache, as: Cache
   alias Nebulex.Ecto.CacheableRepo
@@ -65,7 +66,23 @@ defmodule Nebulex.Ecto.RepoTest do
     assert CacheableRepo.get!(MySchema, 1)
   end
 
-  test "get_by and get_by!" do
+  test "get_by and get_by! when queryable is a schema" do
+    schema = %MySchema{id: 1, x: "abc"}
+    {:ok, _} = Repo.insert(schema)
+
+    refute Cache.get({MySchema, 1})
+
+    assert CacheableRepo.get_by((from e in MySchema), id: 1)
+    assert Cache.get({MySchema, [id: 1]})
+    assert Cache.get!({MySchema, [id: 1]})
+
+    refute CacheableRepo.get_by(MySchema, [id: -1])
+    assert_raise Ecto.NoResultsError, fn ->
+      CacheableRepo.get_by!(MySchema, [id: -1])
+    end
+  end
+
+  test "get_by and get_by! when queryable is a query" do
     schema = %MySchema{id: 1, x: "abc"}
     {:ok, _} = Repo.insert(schema)
 

--- a/test/nebulex_ecto/repo_test.exs
+++ b/test/nebulex_ecto/repo_test.exs
@@ -1,6 +1,7 @@
 defmodule Nebulex.Ecto.RepoTest do
   use ExUnit.Case, async: true
 
+  import Ecto.Query
   alias Nebulex.Ecto.TestRepo, as: Repo
   alias Nebulex.Ecto.TestCache, as: Cache
   alias Nebulex.Ecto.CacheableRepo
@@ -65,7 +66,23 @@ defmodule Nebulex.Ecto.RepoTest do
     assert CacheableRepo.get!(MySchema, 1)
   end
 
-  test "get_by and get_by!" do
+  test "get_by and get_by! when queryable is a schema" do
+    schema = %MySchema{id: 1, x: "abc"}
+    {:ok, _} = Repo.insert(schema)
+
+    refute Cache.get({MySchema, 1})
+
+    assert CacheableRepo.get_by((from e in MySchema), id: 1)
+    assert Cache.get({MySchema, [id: 1]})
+    assert Cache.get!({MySchema, [id: 1]})
+
+    refute CacheableRepo.get_by(MySchema, [id: -1])
+    assert_raise Ecto.NoResultsError, fn ->
+      CacheableRepo.get_by!(MySchema, [id: -1])
+    end
+  end
+
+  test "get_by and get_by! when queryable is a query" do
     schema = %MySchema{id: 1, x: "abc"}
     {:ok, _} = Repo.insert(schema)
 
@@ -73,6 +90,7 @@ defmodule Nebulex.Ecto.RepoTest do
     assert CacheableRepo.get_by(MySchema, [id: 1])
     assert Cache.get({MySchema, [id: 1]})
     assert Cache.get!({MySchema, [id: 1]})
+    refute Cache.get({Ecto.Query, [id: 1]})
 
     refute CacheableRepo.get_by(MySchema, [id: -1])
     assert_raise Ecto.NoResultsError, fn ->


### PR DESCRIPTION
Workaround:

You have 2 defined schemas with common fields like this:

```elixir
  defmodule SchemaOne do
    use Ecto.Schema

    schema "schema_one" do
      field :x, :string
      field :y, :binary
    end
  end
```
and
```elixir
  defmodule SchemaTwo do
    use Ecto.Schema

    schema "schema_two" do
      field :x, :string
      field :z, :binary
    end
  end
```
When you try to put in Cache this:
```elixir
CacheableRepo.get_by((from o in SchemaOne). x: 1)
```
and then try to put in cache the another schema with the same clause
```elixir
CacheableRepo.get_by((from o in SchemaTwo). x: 1)
```
Both keys will be `{Ecto.Query, [x: 1]}`, so you will having a conflict on cached data

Extracting root node schema from `Ecto.Query` you can solve that problem, getting `{SchemaOne, [x: 1]}` and `{SchemaTwo, [x: 1]}` keys respectively in cache with separated data.